### PR TITLE
[OS-349] Icon: Lower app icon priority

### DIFF
--- a/res/icon/tactile.app
+++ b/res/icon/tactile.app
@@ -14,5 +14,5 @@
     "launch_command": "tactile",
     "overrides": [],
 
-    "priority": 1050
+    "priority": 680
 }


### PR DESCRIPTION
Lower the priority to allow Terminal Quest and Song Maker to be on the
first page.