### PR TITLE
[OS-330] Home Button: Hide while running

### DIFF
--- a/build/headers.pri
+++ b/build/headers.pri
@@ -10,6 +10,7 @@ INCLUDEPATH += $$PWD/../include
 HEADER_FILES = \
     app.h \
     display_screen.h \
+    home_button.h \
     hw.h \
     progress.h \
     touch.h \

--- a/build/sources.pri
+++ b/build/sources.pri
@@ -27,6 +27,7 @@ macx {
 
 PLATFORM_SRC_FILES = \
     display_screen.cpp \
+    home_button.cpp \
     hw.cpp \
     progress.cpp \
     touch.cpp \

--- a/include/home_button.h
+++ b/include/home_button.h
@@ -1,0 +1,22 @@
+/**
+ * home_button.h
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+ *
+ * Controls for the home button
+ */
+
+
+#ifndef __TACTILE_HOME_BUTTON_H__
+#define __TACTILE_HOME_BUTTON_H__
+
+
+namespace HomeButton
+{
+    void hide_home_button();
+    void show_home_button();
+};
+
+
+#endif  // __TACTILE_HOME_BUTTON_H__

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -16,6 +16,7 @@
 #include <QDebug>
 
 #include "app.h"
+#include "home_button.h"
 
 
 App::App(int &argc, char **argv) :
@@ -54,6 +55,7 @@ App::App(int &argc, char **argv) :
     Logger::set_app_name("tactile");
     Logger::install_syslog();
 
+    HomeButton::hide_home_button();
     this->tracker.start_session();
     this->engine.load(QUrl(QStringLiteral("qrc:/ui/main.qml")));
 }
@@ -61,6 +63,7 @@ App::App(int &argc, char **argv) :
 
 App::~App()
 {
+    HomeButton::show_home_button();
     this->tracker.end_session();
 }
 

--- a/src/platforms/linux/home_button.cpp
+++ b/src/platforms/linux/home_button.cpp
@@ -1,0 +1,29 @@
+/**
+ * home_button.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+ *
+ * Controls for the home button
+ */
+
+
+#include <QProcess>
+
+#include "home_button.h"
+
+
+void HomeButton::hide_home_button()
+{
+    QProcess proc;
+    proc.start("kano-home-button-visible no");
+    proc.waitForFinished();
+}
+
+
+void HomeButton::show_home_button()
+{
+    QProcess proc;
+    proc.start("kano-home-button-visible yes");
+    proc.waitForFinished();
+}

--- a/src/platforms/macosx/home_button.cpp
+++ b/src/platforms/macosx/home_button.cpp
@@ -1,0 +1,25 @@
+/**
+ * home_button.cpp
+ *
+ * Copyright (C) 2018 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPLv2
+ *
+ * Controls for the home button
+ */
+
+
+#include <QDebug>
+
+#include "home_button.h"
+
+
+void HomeButton::hide_home_button()
+{
+    qDebug() << "Hiding home button";
+}
+
+
+void HomeButton::show_home_button()
+{
+    qDebug() << "Showing home button";
+}


### PR DESCRIPTION
Prevent the user accidentally pressing the home button while they are
using the app by hiding it during runtime.