### PR TITLE
[OS-330] X11: Capture mouse events while running

### DIFF
--- a/build/headers.pri
+++ b/build/headers.pri
@@ -13,8 +13,10 @@ HEADER_FILES = \
     home_button.h \
     hw.h \
     progress.h \
+    Singleton.h \
     touch.h \
-    tracker.h
+    tracker.h \
+    X11Input.h
 
 for (HEADER, HEADER_FILES) {
     HEADERS *= $$INCLUDEPATH/$$HEADER

--- a/build/sources.pri
+++ b/build/sources.pri
@@ -9,7 +9,8 @@
 SRC_DIR = $$PWD/../src
 SRC_FILES = \
     app.cpp \
-    main.cpp
+    main.cpp \
+    X11Input.cpp
 
 for (SRC, SRC_FILES) {
     SOURCES *= $$SRC_DIR/$$SRC

--- a/include/Singleton.h
+++ b/include/Singleton.h
@@ -1,0 +1,39 @@
+/**
+ * Singleton.h
+ *
+ * Copyright (C) 2017 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * Inspired from http://stackoverflow.com/questions/1008019/c-singleton-design-pattern
+ */
+
+
+#ifndef __SINGLETON_H__
+#define __SINGLETON_H__
+
+
+template <class T> class Singleton
+{
+    public:
+        static T& getInstance() {
+            static T instance;  // Guaranteed to be destroyed.
+                                // Instantiated on first use.
+            return instance;
+        }
+
+    public:
+        Singleton(Singleton const&)      = delete;
+        void operator=(Singleton const&) = delete;
+
+        // Note: Scott Meyers mentions in his Effective Modern
+        //       C++ book, that deleted functions should generally
+        //       be public as it results in better error messages
+        //       due to the compilers behavior to check accessibility
+        //       before deleted status
+
+    protected:
+        Singleton() {}        // Constructor? (the {} brackets) are needed here.
+};
+
+
+#endif

--- a/include/X11Input.h
+++ b/include/X11Input.h
@@ -1,0 +1,36 @@
+/**
+ * X11Input.h
+ *
+ * Copyright (C) 2017 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * Wrapper class to deal with hiding and disabling the X11 cursor.
+ * TODO: turn this into a Singleton rather than a static class.
+ */
+
+
+#ifndef __X11MOUSE_H__
+#define __X11MOUSE_H__
+
+
+#include <QProcess>
+
+#include "Singleton.h"
+
+
+class X11Input: public Singleton<X11Input>
+{
+    public:
+        void initialise();
+        void clean();
+
+        void capture();
+        void restore();
+        bool isRunning();
+
+    private:
+        QProcess m_inputProcess;
+};
+
+
+#endif

--- a/src/X11Input.cpp
+++ b/src/X11Input.cpp
@@ -1,0 +1,66 @@
+/**
+ * X11Input.cpp
+ *
+ * Copyright (C) 2017 Kano Computing Ltd.
+ * License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+ *
+ * Wrapper class to deal with hiding and disabling the X11 cursor
+ */
+
+
+#include <QProcess>
+#include <QDebug>
+
+#include "X11Input.h"
+
+
+void X11Input::initialise() {
+    m_inputProcess.setProgram("kano-dashboard-cursor");
+    m_inputProcess.setProcessChannelMode(QProcess::ForwardedChannels);
+}
+
+void X11Input::capture() {
+    #ifdef __arm__
+        // Hide and disable the X11 cursor throughout our running lifetime
+        if (!isRunning()) {
+            m_inputProcess.start();
+        } else {
+            #ifdef QT_DEBUG
+                qDebug() << "X11Input: capture: Process is already running!";
+            #endif
+        }
+    #elif defined QT_DEBUG
+        qDebug() << "X11Input: capture: Nothing to do on this platform!";
+    #endif
+}
+
+void X11Input::restore() {
+    #ifdef __arm__
+        if (isRunning()) {
+            #ifdef QT_DEBUG
+                qDebug() << "X11Input: restore: Terminating process..";
+            #endif
+            m_inputProcess.kill();
+            m_inputProcess.waitForFinished(300);  // ms
+        }
+    #elif defined QT_DEBUG
+        qDebug() << "X11Input: restore: Nothing to do on this platform!";
+    #endif
+}
+
+bool X11Input::isRunning() {
+    bool isRunning = !(m_inputProcess.state() == QProcess::NotRunning);
+    #ifdef QT_DEBUG
+        qDebug() << "X11Input: isRunning:" << isRunning;
+    #endif
+    return isRunning;
+}
+
+void X11Input::clean() {
+    if (m_inputProcess.state() == QProcess::Running) {
+        #ifdef QT_DEBUG
+            qDebug() << "X11Input: clean: Terminating process..";
+        #endif
+        m_inputProcess.kill();
+    }
+}

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -17,6 +17,7 @@
 
 #include "app.h"
 #include "home_button.h"
+#include "X11Input.h"
 
 
 App::App(int &argc, char **argv) :
@@ -56,6 +57,13 @@ App::App(int &argc, char **argv) :
     Logger::install_syslog();
 
     HomeButton::hide_home_button();
+
+    // Initialise the X11 input grabbing singleton.
+    X11Input::getInstance().initialise();
+
+    // Capture X11 input from propagating behind the Qt app and hide X11 cursor.
+    X11Input::getInstance().capture();
+
     this->tracker.start_session();
     this->engine.load(QUrl(QStringLiteral("qrc:/ui/main.qml")));
 }
@@ -63,6 +71,10 @@ App::App(int &argc, char **argv) :
 
 App::~App()
 {
+    // Restore X11 input
+    X11Input::getInstance().restore();
+    X11Input::getInstance().clean();
+
     HomeButton::show_home_button();
     this->tracker.end_session();
 }


### PR DESCRIPTION
Without capturing the X11 mouse events it is possible to "click through"
the app and launch things behind. Prevent this by capturing the mouse
while running.