### PR TITLE
[OS-357] Fixed particle spawn performance in the TouchAGrid scene

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ tactile (4.2.0-0) unstable; urgency=low
 
   * Fixed minor spelling errors
   * Added sound effects to pixel coordinates quiz scene
+  * Fixed particle spawn performance in the TouchAGrid scene
 
  -- Team Kano <dev@kano.me>  Fri, 5 Oct 2018 11:36:37 +0100
 

--- a/res/ui/Tactile/Wires/touch_a_grid.qml
+++ b/res/ui/Tactile/Wires/touch_a_grid.qml
@@ -139,12 +139,12 @@ Item {
 
         Repeater {
             id: touch_emitters
-            model: touch_area.current_touch_points
+            model: 10
 
             Repeater {
                 model: 2
                 property int touch_index: index
-                property TouchPoint touch_point: touch_area.current_touch_points[index]
+                property TouchPoint touch_point: index < touch_area.current_touch_points.length ? touch_area.current_touch_points[index] : null
 
                 Emitter {
                     property real angle: index * Math.PI / 2
@@ -172,5 +172,4 @@ Item {
             alpha: 1.0
         }
     }
-
 }


### PR DESCRIPTION
Previously, when touching the grid repeatedly with 10 fingers
the particle emitters would get destroyed and instantiated every
time the number of touch points changed. This made the scene grind
to a halt. Fix this by locking the particle emitters and not
trimming them.

Thanks for the help with this one @tombettany 