### PR TITLE
 [OS-506] Icon: Mark to only be shown on touch-capable devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,8 +5,9 @@ tactile (4.2.0-0) unstable; urgency=low
   * Fixed particle spawn performance in the TouchAGrid scene
   * Normalised scene transition times to give users enough
     time to read instructions
+  * Mark the app to be shown only for touch-capable devices
 
- -- Team Kano <dev@kano.me>  Mon, 8 Oct 2018 11:36:37 +0100
+ -- Team Kano <dev@kano.me>  Tue, 30 Oct 2018 12:21:00 +0000
 
 tactile (4.1.0-0) unstable; urgency=low
 

--- a/res/icon/tactile.app
+++ b/res/icon/tactile.app
@@ -14,5 +14,7 @@
     "launch_command": "tactile",
     "overrides": [],
 
+    "touch_only": true,
+
     "priority": 680
 }


### PR DESCRIPTION
Prevent the app from being displayed on devices which don't support
touch input.

Harmless as it but will start working as soon as https://github.com/KanoComputing/kano-apps/pull/135 is merged.